### PR TITLE
ci: add Android builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,10 @@ include:
     file: '/osx-arm64.yml'
 
   ################################## CELLULAR ################################
+  # Android
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/android-jni.yml'
+
   # iOS
   - project: 'libretro-infrastructure/ci-templates'
     file: '/ios-arm64.yml'
@@ -127,6 +131,29 @@ libretro-build-osx-arm64:
     - .core-defs
 
 ################################### CELLULAR #################################
+# Android ARMv7a
+android-armeabi-v7a:
+  extends:
+    - .libretro-android-jni-armeabi-v7a
+    - .core-defs
+
+# Android ARMv8a
+android-arm64-v8a:
+  extends:
+    - .libretro-android-jni-arm64-v8a
+    - .core-defs
+
+# Android 64-bit x86
+android-x86_64:
+  extends:
+    - .libretro-android-jni-x86_64
+    - .core-defs
+
+# Android 32-bit x86
+android-x86:
+  extends:
+    - .libretro-android-jni-x86
+    - .core-defs
 
 # iOS
 libretro-build-ios-arm64:

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,0 +1,15 @@
+LOCAL_PATH := $(call my-dir)
+
+CORE_DIR := $(LOCAL_PATH)/..
+
+include $(CORE_DIR)/libretro/Makefile.common
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE       := retro
+LOCAL_SRC_FILES    := $(SOURCES_C)
+LOCAL_CFLAGS       := -O2 -D__LIBRETRO__ -DNDEBUG -Werror=implicit-function-declaration
+LOCAL_C_INCLUDES   := $(CORE_DIR) $(CORE_DIR)/libretro
+LOCAL_LDFLAGS      := -Wl,-version-script=$(CORE_DIR)/libretro/link.T
+
+include $(BUILD_SHARED_LIBRARY)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,0 +1,3 @@
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
+APP_PLATFORM := android-21
+APP_OPTIM := release

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -344,17 +344,11 @@ CXXFLAGS += -std=c++98
 
 CORE_DIR := ..
 
-OBJS := $(CORE_DIR)/libretro/libretro.o \
-        $(CORE_DIR)/main.o \
-        $(CORE_DIR)/apu.o \
-	$(CORE_DIR)/cpu.o \
-	$(CORE_DIR)/input.o \
-	$(CORE_DIR)/mbc.o \
-	$(CORE_DIR)/mem.o \
-	$(CORE_DIR)/ppu.o
+include $(CORE_DIR)/libretro/Makefile.common
+
+OBJS := $(SOURCES_C:.c=.o)
 
 DEFINES  += -D__LIBRETRO__ $(PLATFORM_DEFINES)
-INCFLAGS += -I. -I..
 
 
 CFLAGS   += $(fpic) $(DEFINES) -Werror=implicit-function-declaration

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -1,0 +1,10 @@
+SOURCES_C := $(CORE_DIR)/libretro/libretro.c \
+	$(CORE_DIR)/main.c \
+	$(CORE_DIR)/apu.c \
+	$(CORE_DIR)/cpu.c \
+	$(CORE_DIR)/input.c \
+	$(CORE_DIR)/mbc.c \
+	$(CORE_DIR)/mem.c \
+	$(CORE_DIR)/ppu.c
+
+INCFLAGS := -I$(CORE_DIR) -I$(CORE_DIR)/libretro


### PR DESCRIPTION
The core has never had a `jni/` directory, so the buildbot could not build it for Android — that is the one platform missing from an otherwise complete matrix. This adds one, plus the four Android jobs.

The source list moves to `libretro/Makefile.common` so that `libretro/Makefile` and `jni/Android.mk` read it from one place instead of drifting apart. Everything else is what the make build was already using: the same objects, the same include paths, the same version script. Every other platform builds exactly what it built before — the unix build's link line is unchanged object for object.

Preflight on GitHub Actions (ndk-build, the same command and layout the `android-jni` template uses): all four ABIs build, and the stripped core exports the `retro_*` entry points.

| ABI | |
|---|---|
| armeabi-v7a | ok |
| arm64-v8a | ok |
| x86 | ok |
| x86_64 | ok |
